### PR TITLE
Fixed enclosed variable being overwritten error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = (function() {
     }.bind(this));
 
     for (var path in this.routes) {
-      (function () {
+      (function (path) {
         handler.on(path, function(data) {
           for (var c in this.routes[path]) {
             this.routes[path][c](data);

--- a/index.js
+++ b/index.js
@@ -63,11 +63,13 @@ module.exports = (function() {
     }.bind(this));
 
     for (var path in this.routes) {
-      handler.on(path, function(data) {
-        for (var c in this.routes[path]) {
-          this.routes[path][c](data);
-        }
-      }.bind(this));
+      (function () {
+        handler.on(path, function(data) {
+          for (var c in this.routes[path]) {
+            this.routes[path][c](data);
+          }
+        }.bind(this));
+      })(path);
     }
   }
 


### PR DESCRIPTION
The path variable is overwritten in the closure from the outer for loop. This causes the handler to call the wrong methods in most cases. Example:

var c = new chimneypot();
c.route('push', function(){console.log('push');});
c.route('delete', function(){console.log('delete');});

When a push or delete is triggered, the delete method is called.
